### PR TITLE
Fixed migration AddSentAtInTokensTable

### DIFF
--- a/database/migrations/2022_01_19_000001_add_sent_at_in_tokens_table.php
+++ b/database/migrations/2022_01_19_000001_add_sent_at_in_tokens_table.php
@@ -19,7 +19,7 @@ class AddSentAtInTokensTable extends Migration
             return;
         }
 
-        Schema::create($this->tokenTable, function (Blueprint $table) {
+        Schema::table($this->tokenTable, function (Blueprint $table) {
             $table->timestamp('sent_at')->nullable();
         });
     }


### PR DESCRIPTION
Fix for [ Duplication of migrations on publish #176 ](https://github.com/mohammad-fouladgar/laravel-mobile-verification/issues/176). The migration was attempting to create the token table instead of just adding a column to it.